### PR TITLE
fetch nfts for connected wallet

### DIFF
--- a/src/pages/subheader/index.tsx
+++ b/src/pages/subheader/index.tsx
@@ -1,20 +1,90 @@
-import { FunctionComponent } from "react";
+import { FunctionComponent, useState } from "react";
 import "./../../index.css";
 import Header from "../header/index";
+import { nft } from "../../types";
+
+declare global {
+  interface Window {
+    ethereum: any;
+  }
+}
 
 interface subHeaderProps {
   link: string;
 }
 
 const SubHeader: FunctionComponent<subHeaderProps> = (props) => {
+  const [currentAccount, setCurrentAccount] = useState(null);
+  const [nfts, setNFTs] = useState<nft[]>([]);
+
+  const fetchNFTs = () => {
+    fetch(
+      "https://testnets-api.opensea.io/api/v1/assets?owner=0xE2a6C9dAAFD438A04550E29087Bd839292ff82E5&order_direction=desc&offset=0&limit=20",
+      { method: "GET" }
+    )
+      .then((response) => response.json())
+      .then((response) => {
+        const { assets } = response;
+
+        const nfts = assets.map((asset: any) => {
+          const nft: nft = {
+            id: asset.asset_contract.address,
+            name: asset.asset_contract.description,
+            image: asset.image_url,
+          };
+
+          console.log(nft);
+          return nft;
+        });
+
+        setNFTs(nfts);
+      })
+      .catch((err) => console.error(err));
+  };
+
+  const connectWalletAction = async () => {
+    try {
+      const { ethereum } = window;
+
+      if (!ethereum) {
+        alert("Download the Metamask extension from the Chrome App Store");
+        return;
+      }
+
+      /*
+       * Fancy method to request access to account.
+       */
+      const accounts = await ethereum.request({
+        method: "eth_requestAccounts",
+      });
+
+      /*
+       * Boom! This should print out public address once we authorize Metamask.
+       */
+      console.log("Connected", accounts[0]);
+      setCurrentAccount(accounts[0]);
+
+      fetchNFTs();
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  console.log(nfts);
   return (
     <div className="bg-primary">
+      <div>
+        {nfts.map((nft, i) => (
+          <img width={40} key={`nft_${i}`} src={nft.image} />
+        ))}
+      </div>
+
       <div className="grid-asym-3 font-bold just-cont-end font-color-secondary py-3">
         <div className="grid-col-span-2 text-end fs-2 align-item-bot line-height-a">
           VOTE
         </div>
         <div className="fs-5 d-flex align-item-bot">
-          <a href={props.link}>{">>>Connect Wallet"}</a>
+          <button onClick={connectWalletAction}>{">>>Connect Wallet"}</button>
         </div>
         <div className="text-end fs-3 d-flex align-item-top line-height-a">
           ON

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -1,0 +1,5 @@
+export type nft = {
+  id: string;
+  name: string;
+  image: string;
+};


### PR DESCRIPTION
- Adds the Connect Wallet functionality
- The button styling has to be updated as per design
- Fetches NFTs using the Opensea API for the connected wallet

## Flow
1. User clicks Connect Wallet
2. Metamask extension will pop up asking for creds
3. User logs in. We fetch their NFTs in the background.

## Screenshots
My test wallet has a few fake NFTs. After the flow, the app looks like this:
<img width="1354" alt="Screen Shot 2022-02-20 at 5 12 08 PM" src="https://user-images.githubusercontent.com/6132555/154866591-f10f12b4-4da5-4d21-9b35-ae52632c1c45.png">

## Testing 
If your wallet doesn't have nfts that can be used for this, I recommend setting sample data on line 18 of subheader/index.tsx.

## API
This API call gets all of nfts associated with my wallet. You can use an object from here as sample data.
https://testnets-api.opensea.io/api/v1/assets?owner=0xE2a6C9dAAFD438A04550E29087Bd839292ff82E5&order_direction=desc&offset=0&limit=20

